### PR TITLE
feat(sui): update Sui configuration for improved polling and concurrency; enhance error handling in block retrieval

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -167,10 +167,18 @@ chains:
     internal_code: "SUI_MAINNET"
     type: "sui"
     start_block: 0
-    poll_interval: "5s"
+    poll_interval: "1s"
     nodes:
       - url: "fullnode.mainnet.sui.io:443" # e.g. 127.0.0.1:9000
       - url: "sui-mainnet.nodeinfra.com:443"
+    client:
+      timeout: "12s"
+      max_retries: 2
+      retry_delay: "1s"
+    throttle:
+      batch_size: 200
+      concurrency: 12
+      parallel: true
 
   osmosis_mainnet:
     network_id: "osmosis-1"

--- a/internal/indexer/sui.go
+++ b/internal/indexer/sui.go
@@ -134,10 +134,19 @@ func (s *SuiIndexer) GetBlocksByNumbers(
 	ctx context.Context,
 	blockNumbers []uint64,
 ) ([]BlockResult, error) {
-	// Limit concurrency to avoid overwhelming the node
-	// Default to 10 concurrent requests
-	const maxConcurrency = 10
-	sem := semaphore.NewWeighted(maxConcurrency)
+	if len(blockNumbers) == 0 {
+		return nil, nil
+	}
+
+	// Use configured concurrency when available, fallback to a safe default.
+	workers := s.cfg.Throttle.Concurrency
+	if workers <= 0 {
+		workers = 10
+	}
+	if workers > 50 {
+		workers = 50
+	}
+	sem := semaphore.NewWeighted(int64(workers))
 
 	// Results map protected by mutex
 	resultsMap := make(map[uint64]BlockResult)
@@ -175,15 +184,23 @@ func (s *SuiIndexer) GetBlocksByNumbers(
 
 	wg.Wait()
 
-	// Convert map to slice in order of requested blockNumbers
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Convert map to slice in order of requested blockNumbers and surface first error.
 	results := make([]BlockResult, 0, len(blockNumbers))
+	var firstErr error
 	for _, num := range blockNumbers {
 		if res, ok := resultsMap[num]; ok {
 			results = append(results, res)
+			if firstErr == nil && res.Error != nil {
+				firstErr = fmt.Errorf("block %d: %s", res.Number, res.Error.Message)
+			}
 		}
 	}
 
-	return results, nil
+	return results, firstErr
 }
 
 // IsHealthy does a quick gRPC health check by asking for the latest checkpoint.


### PR DESCRIPTION
### PR Description
## Summary
This PR improves Sui indexer polling performance and makes block-fetch failures visible earlier during batched retrieval.

## Changes
- Reduced `sui_mainnet` `poll_interval` from `5s` to `1s`.
- Added Sui `client` config:
  - `timeout: 12s`
  - `max_retries: 2`
  - `retry_delay: 1s`
- Added Sui `throttle` config:
  - `batch_size: 200`
  - `concurrency: 12`
  - `parallel: true`
- Updated `GetBlocksByNumbers` in the Sui indexer:
  - Early return when input is empty.
  - Uses `s.cfg.Throttle.Concurrency` instead of a hardcoded value (fallback `10`, capped at `50`).
  - Checks `ctx.Err()` after goroutines complete.
  - Stops swallowing block fetch errors and returns the first encountered error in format `block <number>: <message>`.

## Why
- Increases polling throughput under load.
- Makes concurrency tunable via config instead of code changes.
- Improves observability and debugging when partial batch fetches fail.

## Testing
- `go test ./internal/indexer/...` passed.