### PR TITLE
fix: unset CHAINS env var before Viper config load to prevent YAML ov…

### DIFF
--- a/pkg/common/config/load.go
+++ b/pkg/common/config/load.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
@@ -12,6 +13,10 @@ import (
 var validate = validator.New()
 
 func Load(path string) (*Config, error) {
+	// Unset CHAINS env var to prevent Viper from overriding the
+	// "chains" map in the YAML config with a plain string value.
+	os.Unsetenv("CHAINS")
+
 	v := viper.New()
 	v.SetConfigFile(path)
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))


### PR DESCRIPTION
…erride

The CHAINS environment variable from Docker Compose collides with the top-level "chains" key in config.yaml. Viper's AutomaticEnv replaces the entire chains map with the string value, causing validation failure.