### PR TITLE
Refactor/bitcoin confirmation logic

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -72,7 +72,6 @@ chains:
     type: "btc"
     start_block: 4440000 # recent testnet block
     poll_interval: "60s" # Bitcoin blocks ~10 minutes
-    confirmations: 1
     reorg_rollback_window: 100
     index_change_output: false
     index_utxo: true  # Enable UTXO event extraction and emission (Bitcoin only)
@@ -96,7 +95,6 @@ chains:
     type: "btc"
     start_block: 850000
     poll_interval: "60s"
-    confirmations: 1
     reorg_rollback_window: 100
     index_change_output: false
     index_utxo: true  # Enable UTXO event extraction and emission (Bitcoin only)

--- a/internal/indexer/bitcoin.go
+++ b/internal/indexer/bitcoin.go
@@ -14,16 +14,14 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/common/constant"
 	"github.com/fystack/multichain-indexer/pkg/common/enum"
 	"github.com/fystack/multichain-indexer/pkg/common/types"
-	"github.com/fystack/multichain-indexer/pkg/common/utils"
 	"github.com/shopspring/decimal"
 )
 
 type BitcoinIndexer struct {
-	chainName     string
-	config        config.ChainConfig
-	failover      *rpc.Failover[bitcoin.BitcoinAPI]
-	pubkeyStore   PubkeyStore
-	confirmations uint64
+	chainName   string
+	config      config.ChainConfig
+	failover    *rpc.Failover[bitcoin.BitcoinAPI]
+	pubkeyStore PubkeyStore
 }
 
 func NewBitcoinIndexer(
@@ -32,15 +30,20 @@ func NewBitcoinIndexer(
 	failover *rpc.Failover[bitcoin.BitcoinAPI],
 	pubkeyStore PubkeyStore,
 ) *BitcoinIndexer {
-	confirmations := cfg.Confirmations
-
 	return &BitcoinIndexer{
-		chainName:     chainName,
-		config:        cfg,
-		failover:      failover,
-		pubkeyStore:   pubkeyStore,
-		confirmations: confirmations,
+		chainName:   chainName,
+		config:      cfg,
+		failover:    failover,
+		pubkeyStore: pubkeyStore,
 	}
+}
+
+// satoshisFromFloat converts a BTC float64 value to satoshis using string-based decimal
+// arithmetic to avoid float64 truncation errors (e.g. 0.1 * 1e8 = 9999999.999...).
+func satoshisFromFloat(value float64) int64 {
+	return decimal.RequireFromString(fmt.Sprintf("%.8f", value)).
+		Mul(decimal.NewFromInt(1e8)).
+		IntPart()
 }
 
 func (b *BitcoinIndexer) GetName() string {
@@ -73,7 +76,6 @@ func (b *BitcoinIndexer) GetBlock(ctx context.Context, number uint64) (*types.Bl
 	var btcBlock *bitcoin.Block
 
 	err := b.failover.ExecuteWithRetry(ctx, func(c bitcoin.BitcoinAPI) error {
-		// Verbosity 3 = full transaction details with prevout data included (Bitcoin Core 25+)
 		block, err := c.GetBlockByHeight(ctx, number, 3)
 		if err != nil {
 			return err
@@ -89,39 +91,83 @@ func (b *BitcoinIndexer) GetBlock(ctx context.Context, number uint64) (*types.Bl
 	return b.convertBlockWithPrevoutResolution(ctx, btcBlock)
 }
 
-// convertBlockWithPrevoutResolution converts a block and resolves prevout data for transactions
+// convertBlockWithPrevoutResolution converts a block and resolves prevout data
+// for transactions that lack it. Prevout resolution runs in parallel using a
+// pool sized to config.Throttle.Concurrency.
 func (b *BitcoinIndexer) convertBlockWithPrevoutResolution(ctx context.Context, btcBlock *bitcoin.Block) (*types.Block, error) {
-	var allTransfers []types.Transaction
-	var allUTXOEvents []types.UTXOEvent
-
 	latestBlock := btcBlock.Height
 	if btcBlock.Confirmations > 0 {
 		latestBlock = btcBlock.Height + btcBlock.Confirmations - 1
 	}
 
-	provider, _ := b.failover.GetBestProvider()
-	var btcClient *bitcoin.BitcoinClient
-	if provider != nil {
-		btcClient, _ = provider.Client.(*bitcoin.BitcoinClient)
-	}
-
+	// Stage 1: Collect indices of transactions missing prevout data.
+	var needsResolution []int
 	for i := range btcBlock.Tx {
 		tx := &btcBlock.Tx[i]
-
 		if tx.IsCoinbase() {
 			continue
 		}
+		if len(tx.Vin) > 0 && tx.Vin[0].PrevOut == nil && tx.Vin[0].TxID != "" {
+			needsResolution = append(needsResolution, i)
+		}
+	}
 
-		if btcClient != nil && len(tx.Vin) > 0 && tx.Vin[0].PrevOut == nil {
-			if tx.Vin[0].TxID != "" {
-				if resolved, err := btcClient.GetTransactionWithPrevouts(ctx, tx.TxID); err == nil {
-					for j := range tx.Vin {
-						if j < len(resolved.Vin) && resolved.Vin[j].PrevOut != nil {
-							tx.Vin[j].PrevOut = resolved.Vin[j].PrevOut
+	// Stage 2: Resolve prevout data in parallel.
+	if len(needsResolution) > 0 {
+		concurrency := b.config.Throttle.Concurrency
+		if concurrency < 1 {
+			concurrency = 1
+		}
+
+		type job struct{ txIdx int }
+		jobs := make(chan job, len(needsResolution))
+		for _, idx := range needsResolution {
+			jobs <- job{txIdx: idx}
+		}
+		close(jobs)
+
+		var wg sync.WaitGroup
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				provider, err := b.failover.GetBestProvider()
+				if err != nil || provider == nil {
+					for range jobs {
+					}
+					return
+				}
+				client, ok := provider.Client.(bitcoin.BitcoinAPI)
+				if !ok {
+					for range jobs {
+					}
+					return
+				}
+				for j := range jobs {
+					tx := &btcBlock.Tx[j.txIdx]
+					resolved, err := client.GetTransactionWithPrevouts(ctx, tx.TxID)
+					if err != nil {
+						continue // silently skip — same behaviour as the previous sequential code
+					}
+					for k := range tx.Vin {
+						if k < len(resolved.Vin) && resolved.Vin[k].PrevOut != nil {
+							tx.Vin[k].PrevOut = resolved.Vin[k].PrevOut
 						}
 					}
 				}
-			}
+			}()
+		}
+		wg.Wait()
+	}
+
+	// Stage 3: Extract transfers and UTXO events.
+	var allTransfers []types.Transaction
+	var allUTXOEvents []types.UTXOEvent
+
+	for i := range btcBlock.Tx {
+		tx := &btcBlock.Tx[i]
+		if tx.IsCoinbase() {
+			continue
 		}
 
 		transfers := b.extractTransfersFromTx(tx, btcBlock.Height, btcBlock.Time, latestBlock)
@@ -142,7 +188,6 @@ func (b *BitcoinIndexer) convertBlockWithPrevoutResolution(ctx context.Context, 
 		Timestamp:    btcBlock.Time,
 		Transactions: allTransfers,
 	}
-
 	block.SetMetadata("utxo_events", allUTXOEvents)
 
 	return block, nil
@@ -242,9 +287,25 @@ func (b *BitcoinIndexer) extractTransfersFromTx(
 	fee := tx.CalculateFee()
 
 	confirmations := b.calculateConfirmations(blockNumber, latestBlock)
-	status := utils.CalculateTransactionStatus(confirmations, b.confirmations)
+	status := types.StatusPending
+	if confirmations > 0 {
+		status = types.StatusConfirmed
+	}
 
 	fromAddr := b.getFirstInputAddress(tx)
+
+	// Build set of all normalized input addresses for change output detection.
+	inputAddrs := make(map[string]bool, len(tx.Vin))
+	for _, vin := range tx.Vin {
+		addr := bitcoin.GetInputAddress(&vin)
+		if addr == "" {
+			continue
+		}
+		if normalized, err := bitcoin.NormalizeBTCAddress(addr); err == nil {
+			addr = normalized
+		}
+		inputAddrs[addr] = true
+	}
 
 	feeAssigned := false
 	for _, vout := range tx.Vout {
@@ -259,12 +320,12 @@ func (b *BitcoinIndexer) extractTransfersFromTx(
 
 		// For Transfer events, respect index_change_output config
 		// (This filters what goes to transfer.event.dispatch)
-		if !b.config.IndexChangeOutput && fromAddr != "" && fromAddr == toAddr {
+		if !b.config.IndexChangeOutput && len(inputAddrs) > 0 && inputAddrs[toAddr] {
 			continue
 		}
 
 		// Convert BTC to satoshis (multiply by 1e8)
-		amountSat := int64(vout.Value * 1e8)
+		amountSat := satoshisFromFloat(vout.Value)
 
 		txFee := decimal.Zero
 		if !feeAssigned {
@@ -318,7 +379,7 @@ func (b *BitcoinIndexer) extractUTXOEvent(
 			addr = normalized
 		}
 
-		amountSat := int64(vout.Value * 1e8)
+		amountSat := satoshisFromFloat(vout.Value)
 
 		created = append(created, types.UTXO{
 			TxHash:       tx.TxID,
@@ -345,7 +406,7 @@ func (b *BitcoinIndexer) extractUTXOEvent(
 			addr = normalized
 		}
 
-		amountSat := int64(vin.PrevOut.Value * 1e8)
+		amountSat := satoshisFromFloat(vin.PrevOut.Value)
 
 		spent = append(spent, types.SpentUTXO{
 			TxHash:  vin.TxID,
@@ -363,7 +424,10 @@ func (b *BitcoinIndexer) extractUTXOEvent(
 	}
 
 	confirmations := b.calculateConfirmations(blockNumber, latestBlock)
-	status := utils.CalculateTransactionStatus(confirmations, b.confirmations)
+	status := types.StatusPending
+	if confirmations > 0 {
+		status = types.StatusConfirmed
+	}
 	fee := tx.CalculateFee()
 
 	return &types.UTXOEvent{
@@ -410,20 +474,6 @@ func (b *BitcoinIndexer) IsHealthy() bool {
 	return err == nil
 }
 
-// GetConfirmedHeight returns the latest block height minus confirmations
-// This ensures we only index blocks with sufficient confirmations to avoid reorgs
-func (b *BitcoinIndexer) GetConfirmedHeight(ctx context.Context) (uint64, error) {
-	latest, err := b.GetLatestBlockNumber(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get latest block: %w", err)
-	}
-
-	if latest < b.confirmations {
-		return 0, nil
-	}
-
-	return latest - b.confirmations, nil
-}
 
 // GetMempoolTransactions fetches and processes transactions from the mempool
 // Returns transactions and UTXO events involving monitored addresses with 0 confirmations

--- a/internal/worker/catchup.go
+++ b/internal/worker/catchup.go
@@ -120,13 +120,6 @@ func (cw *CatchupWorker) loadCatchupProgress() []blockstore.CatchupRange {
 	if len(ranges) == 0 {
 		if latest, err1 := cw.blockStore.GetLatestBlock(cw.chain.GetNetworkInternalCode()); err1 == nil {
 			if head, err2 := cw.chain.GetLatestBlockNumber(cw.ctx); err2 == nil && head > latest {
-				// For chains with confirmation requirements (e.g. Bitcoin), cap the catchup
-				// range at the confirmed height. Without this, catchup processes unconfirmed
-				// blocks that the regular worker can't reach yet, causing an infinite loop
-				// where the same range is re-created and transactions are re-emitted.
-				if cw.config.Confirmations > 0 && head > cw.config.Confirmations {
-					head = head - cw.config.Confirmations
-				}
 				if head <= latest {
 					// no gap between head and latest
 					return ranges

--- a/internal/worker/mempool.go
+++ b/internal/worker/mempool.go
@@ -105,6 +105,16 @@ func (mw *MempoolWorker) processMempool() error {
 			continue
 		}
 
+		// seenTxs grows unbounded as the mempool churns. Once it hits 50k entries,
+		// evict one random entry before inserting the new one to keep memory bounded.
+		// Go map iteration is randomly ordered, so ranging and breaking after the
+		// first delete is a lightweight random-eviction without a separate data structure.
+		if len(mw.seenTxs) >= 50_000 {
+			for k := range mw.seenTxs {
+				delete(mw.seenTxs, k)
+				break
+			}
+		}
 		mw.seenTxs[txKey] = true
 		newTxCount++
 
@@ -178,20 +188,6 @@ func (mw *MempoolWorker) processMempool() error {
 			"new_utxos", newUTXOCount,
 			"total_tracked", len(mw.seenTxs),
 		)
-	}
-
-	// Cleanup: Remove old transactions from tracking (keep last 10k)
-	if len(mw.seenTxs) > 10000 {
-		// Clear half the map (simple approach)
-		count := 0
-		for txKey := range mw.seenTxs {
-			delete(mw.seenTxs, txKey)
-			count++
-			if count > 5000 {
-				break
-			}
-		}
-		mw.logger.Debug("Cleaned up old mempool transactions", "removed", count)
 	}
 
 	// Sleep until next poll interval

--- a/internal/worker/regular.go
+++ b/internal/worker/regular.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/store/pubkeystore"
 )
 
+
 const (
 	MaxBlockHashSize = 20
 )
@@ -84,31 +85,7 @@ func (rw *RegularWorker) processRegularBlocks() error {
 		return fmt.Errorf("get latest block: %w", err)
 	}
 
-	// Bitcoin-specific: Only index confirmed blocks
-	if rw.chain.GetNetworkType() == enum.NetworkTypeBtc {
-		btcIndexer, ok := rw.chain.(*indexer.BitcoinIndexer)
-		if ok {
-			confirmedHeight, err := btcIndexer.GetConfirmedHeight(rw.ctx)
-			if err != nil {
-				return fmt.Errorf("get confirmed height: %w", err)
-			}
-			rw.logger.Info("Got confirmed height for Bitcoin",
-				"latest", latest,
-				"confirmed", confirmedHeight,
-				"current", rw.currentBlock)
-			latest = confirmedHeight
-
-			if rw.currentBlock > latest {
-				rw.logger.Info("Waiting for confirmations",
-					"current", rw.currentBlock,
-					"confirmed_height", latest)
-				time.Sleep(rw.config.PollInterval)
-				return nil
-			}
-		}
-	} else {
-		rw.logger.Info("Got latest block", "latest", latest, "current", rw.currentBlock)
-	}
+	rw.logger.Info("Got latest block", "latest", latest, "current", rw.currentBlock)
 
 	if rw.currentBlock > latest {
 		rw.logger.Info("Waiting for new blocks...", "current", rw.currentBlock, "latest", latest)

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -43,7 +43,6 @@ type ChainConfig struct {
 	StartBlock          int              `yaml:"start_block"           validate:"min=0"`
 	PollInterval        time.Duration    `yaml:"poll_interval"`
 	ReorgRollbackWindow int              `yaml:"reorg_rollback_window"`
-	Confirmations       uint64           `yaml:"confirmations"`
 	IndexChangeOutput   bool             `yaml:"index_change_output"`
 	IndexUTXO           bool             `yaml:"index_utxo"`
 	Client              ClientConfig     `yaml:"client"`

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -44,15 +44,3 @@ func ChunkBySize[T any](slice []T, chunkSize int) [][]T {
 	return chunks
 }
 
-// CalculateTransactionStatus calculates the transaction status based on the number of confirmations and the required confirmations.
-func CalculateTransactionStatus(confirmations, requiredConfirmations uint64) string {
-	const (
-		StatusPending   = "pending"
-		StatusConfirmed = "confirmed"
-	)
-
-	if confirmations < requiredConfirmations {
-		return StatusPending
-	}
-	return StatusConfirmed
-}


### PR DESCRIPTION
# Refactor Bitcoin Confirmation Logic & Indexer Improvements

## Summary

- **Remove confirmations config**  
  The `Confirmations` field has been removed from `ChainConfig` and all related logic. Bitcoin blocks are now indexed directly without an artificial confirmation delay, relying on reorg handling via `reorg_rollback_window` instead.

- **Parallel prevout resolution**  
  `convertBlockWithPrevoutResolution` now fetches missing prevout data concurrently using a worker pool sized to `config.Throttle.Concurrency`, eliminating the previous N+1 sequential RPC pattern.

- **Fee precision fix**  
  BTC → satoshi conversion now uses string-based decimal arithmetic instead of `float64` multiplication, preventing truncation errors (e.g. `0.1 * 1e8 → 9999999` instead of `10000000`).

- **Multi-input change output detection**  
  Change output filtering now checks against **all input addresses** instead of only the first, correctly suppressing change outputs in multi-input transactions.

- **Mempool `seenTxs` bounding**  
  Replaced the 10k-threshold bulk eviction (which removed 5k entries at once) with a **50k-cap random single-entry eviction on each insert**, keeping memory bounded without aggressively purging still-relevant entries.

- **Dead code removal**  
  The following unused components were removed:
  - `CalculateTransactionStatus` utility
  - `GetConfirmedHeight` method
  - Bitcoin-specific confirmed-height block in `RegularWorker`

---

## Test Plan

- Run Bitcoin mainnet indexer and verify blocks are indexed **without confirmation delay**.
- Confirm **no double-emits or reorg misses** with `reorg_rollback_window` in place.
- Verify **satoshi amounts are correct** for known transactions with fractional BTC values.
- Confirm **change outputs are suppressed for multi-input transactions** when `index_change_output: false`.
- Run the **mempool worker** and observe `seenTxs` size stays bounded under sustained load.