### PR TITLE
fix(worker): don't queue catchup from genesis on cold start

### DIFF
--- a/internal/worker/catchup.go
+++ b/internal/worker/catchup.go
@@ -132,12 +132,11 @@ func (cw *CatchupWorker) loadCatchupProgress() []blockstore.CatchupRange {
 
 	// Only create a new range if no existing ranges found
 	if len(ranges) == 0 {
-		if latest, err1 := cw.blockStore.GetLatestBlock(cw.chain.GetNetworkInternalCode()); err1 == nil {
+		// latest == 0 means cold start (GetLatestBlock returns (0, nil) for a
+		// missing key) — there is no prior progress to catch up from, and
+		// queueing 1..head would re-index the whole chain.
+		if latest, err1 := cw.blockStore.GetLatestBlock(cw.chain.GetNetworkInternalCode()); err1 == nil && latest > 0 {
 			if head, err2 := cw.chain.GetLatestBlockNumber(cw.ctx); err2 == nil && head > latest {
-				if head <= latest {
-					// no gap between head and latest
-					return ranges
-				}
 				start, end := latest+1, head
 				cw.logger.Info("Creating new catchup range",
 					"chain", cw.chain.GetName(),

--- a/internal/worker/regular_test.go
+++ b/internal/worker/regular_test.go
@@ -465,3 +465,47 @@ func (s *stubBlockStore) SaveBlockHashes(string, []blockstore.BlockHashEntry) er
 func (s *stubBlockStore) Close() error {
 	return nil
 }
+
+func TestCatchupWorkerLoadCatchupProgressColdStartQueuesNothing(t *testing.T) {
+	t.Parallel()
+
+	// Cold start: GetLatestBlock returns (0, nil). There is no prior progress,
+	// so no catchup range must be created (regression: issue #104 queued
+	// 1..head and re-indexed the whole chain).
+	store := &stubBlockStore{latestBlock: 0}
+	cw := &CatchupWorker{
+		BaseWorker: &BaseWorker{
+			ctx:            context.Background(),
+			cancel:         func() {},
+			logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+			chain:          &stubIndexer{name: "bsc", internalCode: "BSC", networkType: enum.NetworkTypeEVM, latest: 109195919},
+			blockStore:     store,
+			statusRegistry: status.NewRegistry(),
+		},
+	}
+
+	require.Empty(t, cw.loadCatchupProgress())
+	require.Empty(t, store.savedCatchupRanges)
+}
+
+func TestCatchupWorkerLoadCatchupProgressResumeQueuesGap(t *testing.T) {
+	t.Parallel()
+
+	// Prior progress exists: the gap from KV latest to chain head is queued.
+	store := &stubBlockStore{latestBlock: 100}
+	cw := &CatchupWorker{
+		BaseWorker: &BaseWorker{
+			ctx:            context.Background(),
+			cancel:         func() {},
+			logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+			chain:          &stubIndexer{name: "bsc", internalCode: "BSC", networkType: enum.NetworkTypeEVM, latest: 150},
+			blockStore:     store,
+			statusRegistry: status.NewRegistry(),
+		},
+	}
+
+	ranges := cw.loadCatchupProgress()
+	require.NotEmpty(t, ranges)
+	require.Equal(t, uint64(101), ranges[0].Start)
+	require.Equal(t, uint64(150), ranges[len(ranges)-1].End)
+}


### PR DESCRIPTION
## Problem

Fixes #104 — regression from #102.

PR #102 changed `GetLatestBlock` to return `(0, nil)` for a missing key (cold start) instead of an error. `CatchupWorker.loadCatchupProgress` was not updated: it saw `err == nil` and treated `latest = 0` as a real indexed block, so starting a brand-new chain queued a catchup range from block 1 to chain head — on BSC that's ~109M blocks split into ~5.4M sub-ranges — and hung batch-saving them to the KV store, while also being set up to re-index the whole chain from genesis.

## Changes

- `internal/worker/catchup.go`: skip catchup-range creation when `latest == 0` — a cold start has no prior progress to catch up from; the regular worker anchors on chain head (as designed in #102). Also removed an unreachable `head <= latest` branch.
- `internal/worker/regular_test.go`: regression tests — cold start queues nothing; resume from KV queues exactly the gap.

Audited all other workers (regular, rescanner, recovery, manual, mempool, bloom_sync) — no other call site assumes the old error-on-missing-key behavior.

## Note for operators

Deployments that ran the broken build against a new chain may have millions of junk catchup ranges persisted in Consul/Badger — delete that chain's catchup keys before restarting.

`go build ./...`, `go vet`, and all tests in the affected packages pass.