### PR TITLE
feat(catchup): store catchup progress in a compact Redis hash

### DIFF
--- a/internal/worker/base.go
+++ b/internal/worker/base.go
@@ -17,6 +17,7 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/infra"
 	"github.com/fystack/multichain-indexer/pkg/retry"
 	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/fystack/multichain-indexer/pkg/store/catchupstore"
 	"github.com/fystack/multichain-indexer/pkg/store/pubkeystore"
 )
 
@@ -44,6 +45,7 @@ type BaseWorker struct {
 	chain          indexer.Indexer
 	kvstore        infra.KVStore
 	blockStore     blockstore.Store
+	catchupStore   catchupstore.Store
 	pubkeyStore    pubkeystore.Store
 	emitter        events.Emitter
 	failedChan     chan FailedBlockEvent
@@ -64,6 +66,7 @@ func newWorkerWithMode(
 	cfg config.ChainConfig,
 	kv infra.KVStore,
 	blockStore blockstore.Store,
+	catchupStore catchupstore.Store,
 	emitter events.Emitter,
 	pubkeyStore pubkeystore.Store,
 	mode WorkerMode,
@@ -85,6 +88,7 @@ func newWorkerWithMode(
 		chain:          chain,
 		kvstore:        kv,
 		blockStore:     blockStore,
+		catchupStore:   catchupStore,
 		pubkeyStore:    pubkeyStore,
 		emitter:        emitter,
 		failedChan:     failedChan,

--- a/internal/worker/catchup.go
+++ b/internal/worker/catchup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/events"
 	"github.com/fystack/multichain-indexer/pkg/infra"
 	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/fystack/multichain-indexer/pkg/store/catchupstore"
 	"github.com/fystack/multichain-indexer/pkg/store/pubkeystore"
 )
 
@@ -40,6 +41,7 @@ func NewCatchupWorker(
 	cfg config.ChainConfig,
 	kv infra.KVStore,
 	blockStore blockstore.Store,
+	catchupStore catchupstore.Store,
 	emitter events.Emitter,
 	pubkeyStore pubkeystore.Store,
 	failedChan chan FailedBlockEvent,
@@ -51,6 +53,7 @@ func NewCatchupWorker(
 		cfg,
 		kv,
 		blockStore,
+		catchupStore,
 		emitter,
 		pubkeyStore,
 		ModeCatchup,
@@ -124,7 +127,7 @@ func (cw *CatchupWorker) runCatchup() {
 // reloadStoredRanges returns only persisted ranges, skipping the head-vs-latest
 // auto-create in loadCatchupProgress. Used to pick up ranges queued at runtime.
 func (cw *CatchupWorker) reloadStoredRanges() []blockstore.CatchupRange {
-	progress, err := cw.blockStore.GetCatchupProgress(cw.chain.GetNetworkInternalCode())
+	progress, err := cw.catchupStore.GetProgress(cw.ctx, cw.chain.GetNetworkInternalCode())
 	if err != nil {
 		cw.logger.Warn("Failed to reload catchup progress while idle",
 			"error", err,
@@ -152,7 +155,7 @@ func (cw *CatchupWorker) loadCatchupProgress() []blockstore.CatchupRange {
 	var ranges []blockstore.CatchupRange
 
 	// Load existing catchup ranges from database (they're already split when saved)
-	if progress, err := cw.blockStore.GetCatchupProgress(cw.chain.GetNetworkInternalCode()); err == nil {
+	if progress, err := cw.catchupStore.GetProgress(cw.ctx, cw.chain.GetNetworkInternalCode()); err == nil {
 		cw.logger.Info("Loading existing catchup progress",
 			"progress_ranges", len(progress),
 		)
@@ -188,7 +191,8 @@ func (cw *CatchupWorker) loadCatchupProgress() []blockstore.CatchupRange {
 				})
 
 				// Batch save all split ranges to database
-				if err := cw.blockStore.SaveCatchupRanges(
+				if err := cw.catchupStore.SaveRanges(
+					cw.ctx,
 					cw.chain.GetNetworkInternalCode(),
 					newRanges,
 				); err != nil {
@@ -392,7 +396,7 @@ func (cw *CatchupWorker) saveProgress(r blockstore.CatchupRange, current uint64)
 		"current", current,
 	)
 	current = min(current, r.End)
-	if err := cw.blockStore.SaveCatchupProgress(cw.chain.GetNetworkInternalCode(), r.Start, r.End, current); err != nil {
+	if err := cw.catchupStore.SaveProgress(cw.ctx, cw.chain.GetNetworkInternalCode(), r.Start, r.End, current); err != nil {
 		cw.logger.Warn("Failed to save catchup progress",
 			"range", fmt.Sprintf("%d-%d", r.Start, r.End),
 			"current", current,
@@ -422,7 +426,7 @@ func (cw *CatchupWorker) completeRange(r blockstore.CatchupRange) error {
 		"range", fmt.Sprintf("%d-%d", r.Start, r.End),
 	)
 
-	if err := cw.blockStore.DeleteCatchupRange(cw.chain.GetNetworkInternalCode(), r.Start, r.End); err != nil {
+	if err := cw.catchupStore.DeleteRange(cw.ctx, cw.chain.GetNetworkInternalCode(), r.Start, r.End); err != nil {
 		cw.logger.Warn("Failed to delete catchup range",
 			"range", fmt.Sprintf("%d-%d", r.Start, r.End),
 			"error", err,
@@ -468,7 +472,7 @@ func (cw *CatchupWorker) Close() error {
 		)
 	}
 
-	if err := cw.blockStore.SaveCatchupRanges(cw.chain.GetNetworkInternalCode(), rangesToSave); err != nil {
+	if err := cw.catchupStore.SaveRanges(cw.ctx, cw.chain.GetNetworkInternalCode(), rangesToSave); err != nil {
 		cw.logger.Error("Failed to batch save progress on close",
 			"ranges", len(rangesToSave),
 			"error", err,

--- a/internal/worker/catchup_test.go
+++ b/internal/worker/catchup_test.go
@@ -2,16 +2,99 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
+	"sort"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/fystack/multichain-indexer/internal/indexer"
 	"github.com/fystack/multichain-indexer/pkg/common/enum"
 	"github.com/fystack/multichain-indexer/pkg/common/types"
+	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeCatchupStore is an in-memory catchupstore.Store for a single chain, with
+// deletion tracking so tests can assert a range was completed.
+type fakeCatchupStore struct {
+	mu      sync.Mutex
+	current map[string]uint64 // "start-end" -> current
+	deleted map[string]bool
+}
+
+func newFakeCatchupStore() *fakeCatchupStore {
+	return &fakeCatchupStore{current: map[string]uint64{}, deleted: map[string]bool{}}
+}
+
+func fakeCatchupField(start, end uint64) string {
+	return fmt.Sprintf("%d-%d", start, end)
+}
+
+func (f *fakeCatchupStore) SaveRanges(
+	_ context.Context,
+	_ string,
+	ranges []blockstore.CatchupRange,
+) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, r := range ranges {
+		if r.Start == 0 || r.End < r.Start {
+			continue
+		}
+		f.current[fakeCatchupField(r.Start, r.End)] = r.Current
+	}
+	return nil
+}
+
+func (f *fakeCatchupStore) SaveProgress(
+	_ context.Context,
+	_ string,
+	start, end, current uint64,
+) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.current[fakeCatchupField(start, end)] = current
+	return nil
+}
+
+func (f *fakeCatchupStore) GetProgress(
+	_ context.Context,
+	_ string,
+) ([]blockstore.CatchupRange, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ranges := make([]blockstore.CatchupRange, 0, len(f.current))
+	for field, current := range f.current {
+		var start, end uint64
+		if _, err := fmt.Sscanf(field, "%d-%d", &start, &end); err != nil {
+			continue
+		}
+		ranges = append(ranges, blockstore.CatchupRange{Start: start, End: end, Current: current})
+	}
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].Start < ranges[j].Start })
+	return ranges, nil
+}
+
+func (f *fakeCatchupStore) DeleteRange(
+	_ context.Context,
+	_ string,
+	start, end uint64,
+) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.current, fakeCatchupField(start, end))
+	f.deleted[fakeCatchupField(start, end)] = true
+	return nil
+}
+
+func (f *fakeCatchupStore) hasDeleted(start, end uint64) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.deleted[fakeCatchupField(start, end)]
+}
 
 // newTestCatchupWorker builds a CatchupWorker wired to the given stubs with a
 // short idle interval so the keep-alive loop can be exercised quickly.
@@ -19,18 +102,20 @@ func newTestCatchupWorker(
 	ctx context.Context,
 	chain *stubIndexer,
 	store *stubBlockStore,
+	catchupStore *fakeCatchupStore,
 ) *CatchupWorker {
 	cfg := testChainConfig()
 	return &CatchupWorker{
 		BaseWorker: &BaseWorker{
-			ctx:        ctx,
-			cancel:     func() {},
-			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
-			config:     cfg,
-			chain:      chain,
-			blockStore: store,
-			emitter:    &captureEmitter{},
-			failedChan: make(chan FailedBlockEvent, 8),
+			ctx:          ctx,
+			cancel:       func() {},
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			config:       cfg,
+			chain:        chain,
+			blockStore:   store,
+			catchupStore: catchupStore,
+			emitter:      &captureEmitter{},
+			failedChan:   make(chan FailedBlockEvent, 8),
 		},
 		workerPool:   make(chan struct{}, CATCHUP_WORKERS),
 		idleInterval: 5 * time.Millisecond,
@@ -65,11 +150,12 @@ func TestCatchupWorkerPicksUpRangesQueuedAfterDrain(t *testing.T) {
 	}
 	// Start with no ranges: the loop immediately drains and goes idle.
 	store := &stubBlockStore{latestBlock: 1000}
+	catchupStore := newFakeCatchupStore()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cw := newTestCatchupWorker(ctx, chain, store)
+	cw := newTestCatchupWorker(ctx, chain, store, catchupStore)
 
 	done := make(chan struct{})
 	go func() {
@@ -80,11 +166,11 @@ func TestCatchupWorkerPicksUpRangesQueuedAfterDrain(t *testing.T) {
 	// Simulate the regular worker queuing a catchup range at runtime, after the
 	// catchup loop has already drained and gone idle.
 	time.Sleep(20 * time.Millisecond)
-	require.NoError(t, store.SaveCatchupProgress("BSC_MAINNET", 100, 105, 99))
+	require.NoError(t, catchupStore.SaveProgress(ctx, "BSC_MAINNET", 100, 105, 99))
 
 	// The idle loop should pick it up and complete (delete) it.
 	require.Eventually(t, func() bool {
-		return store.hasDeleted(100, 105)
+		return catchupStore.hasDeleted(100, 105)
 	}, time.Second, 5*time.Millisecond, "queued range was not processed by the keep-alive loop")
 
 	// The loop must still be running (did not exit on drain).

--- a/internal/worker/factory.go
+++ b/internal/worker/factory.go
@@ -19,8 +19,8 @@ import (
 	"github.com/fystack/multichain-indexer/internal/rpc/sui"
 	tonrpc "github.com/fystack/multichain-indexer/internal/rpc/ton"
 	"github.com/fystack/multichain-indexer/internal/rpc/tron"
-	"github.com/fystack/multichain-indexer/internal/status"
 	"github.com/fystack/multichain-indexer/internal/rpc/xrp"
+	"github.com/fystack/multichain-indexer/internal/status"
 	"github.com/fystack/multichain-indexer/pkg/addressbloomfilter"
 	"github.com/fystack/multichain-indexer/pkg/common/config"
 	"github.com/fystack/multichain-indexer/pkg/common/enum"
@@ -31,6 +31,7 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/ratelimiter"
 	"github.com/fystack/multichain-indexer/pkg/repository"
 	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/fystack/multichain-indexer/pkg/store/catchupstore"
 	"github.com/fystack/multichain-indexer/pkg/store/pubkeystore"
 	tonaddr "github.com/xssnick/tonutils-go/address"
 	"gorm.io/gorm"
@@ -41,6 +42,7 @@ type WorkerDeps struct {
 	Ctx            context.Context
 	KVStore        infra.KVStore
 	BlockStore     blockstore.Store
+	CatchupStore   catchupstore.Store
 	Emitter        events.Emitter
 	Pubkey         pubkeystore.Store
 	Redis          infra.RedisClient
@@ -106,6 +108,7 @@ func BuildWorkers(
 				cfg,
 				deps.KVStore,
 				deps.BlockStore,
+				deps.CatchupStore,
 				deps.Emitter,
 				deps.Pubkey,
 				deps.FailedChan,
@@ -120,6 +123,7 @@ func BuildWorkers(
 				cfg,
 				deps.KVStore,
 				deps.BlockStore,
+				deps.CatchupStore,
 				deps.Emitter,
 				deps.Pubkey,
 				deps.FailedChan,
@@ -134,6 +138,7 @@ func BuildWorkers(
 				cfg,
 				deps.KVStore,
 				deps.BlockStore,
+				deps.CatchupStore,
 				deps.Emitter,
 				deps.Pubkey,
 				deps.FailedChan,
@@ -149,6 +154,7 @@ func BuildWorkers(
 				deps.KVStore,
 				deps.Redis,
 				deps.BlockStore,
+				deps.CatchupStore,
 				deps.Emitter,
 				deps.Pubkey,
 				deps.FailedChan,
@@ -163,6 +169,7 @@ func BuildWorkers(
 				cfg,
 				deps.KVStore,
 				deps.BlockStore,
+				deps.CatchupStore,
 				deps.Emitter,
 				deps.Pubkey,
 				deps.FailedChan,
@@ -863,6 +870,7 @@ func CreateManagerWithWorkers(
 ) *Manager {
 	// Shared stores
 	blockStore := blockstore.NewBlockStore(kvstore)
+	catchupStore := catchupstore.New(redisClient, blockStore)
 	pubkeyStore := pubkeystore.NewPublicKeyStore(addressBF)
 	statusRegistry := status.NewRegistry()
 
@@ -907,7 +915,7 @@ func CreateManagerWithWorkers(
 		if existingFailed, err := blockStore.GetFailedBlocks(idxr.GetNetworkInternalCode()); err == nil {
 			statusRegistry.SetFailedBlocks(idxr.GetName(), existingFailed)
 		}
-		if existingCatchup, err := blockStore.GetCatchupProgress(idxr.GetNetworkInternalCode()); err == nil {
+		if existingCatchup, err := catchupStore.GetProgress(ctx, idxr.GetNetworkInternalCode()); err == nil {
 			statusRegistry.SetCatchupRanges(idxr.GetName(), existingCatchup)
 		} else {
 			logger.Warn("Failed to load catchup progress for status registry",
@@ -924,6 +932,7 @@ func CreateManagerWithWorkers(
 			Ctx:            ctx,
 			KVStore:        kvstore,
 			BlockStore:     blockStore,
+			CatchupStore:   catchupStore,
 			Emitter:        emitter,
 			Pubkey:         pubkeyStore,
 			Redis:          redisClient,

--- a/internal/worker/factory_test.go
+++ b/internal/worker/factory_test.go
@@ -118,8 +118,8 @@ func TestRescannerFailedChannelIsolationByChain(t *testing.T) {
 	chA := make(chan FailedBlockEvent, 1)
 	chB := make(chan FailedBlockEvent, 1)
 
-	rwA := NewRescannerWorker(ctx, chainA, testChainConfig(), noopKVStore{}, &stubBlockStore{}, events.Emitter(nil), nil, chA, nil)
-	rwB := NewRescannerWorker(ctx, chainB, testChainConfig(), noopKVStore{}, &stubBlockStore{}, events.Emitter(nil), nil, chB, nil)
+	rwA := NewRescannerWorker(ctx, chainA, testChainConfig(), noopKVStore{}, &stubBlockStore{}, nil, events.Emitter(nil), nil, chA, nil)
+	rwB := NewRescannerWorker(ctx, chainB, testChainConfig(), noopKVStore{}, &stubBlockStore{}, nil, events.Emitter(nil), nil, chB, nil)
 
 	doneA := make(chan struct{})
 	doneB := make(chan struct{})
@@ -172,12 +172,17 @@ func TestCreateManagerWithWorkersBootstrapsCatchupRangesIntoStatusRegistry(t *te
 		},
 	}
 
+	// Legacy one-key-per-range catchup state in the KV store; the manager should
+	// lazily migrate it into the Redis hash and bootstrap the status registry.
 	kv := &listKVStore{
 		pairs: []*infra.KVPair{{
 			Key:   fmt.Sprintf("%s/%s/%s/%d-%d", blockstore.BlockStates, "a", constant.KVPrefixProgressCatchup, 1, 20),
 			Value: []byte("10"),
 		}},
 	}
+
+	redisClient := dialTestRedis(t)
+	flushCatchupKeys(t, redisClient, "a")
 
 	manager := CreateManagerWithWorkers(
 		context.Background(),
@@ -186,7 +191,7 @@ func TestCreateManagerWithWorkersBootstrapsCatchupRangesIntoStatusRegistry(t *te
 		nil,
 		nil,
 		events.Emitter(nil),
-		nil,
+		redisClient,
 		ManagerConfig{
 			Chains: []string{"chain-a"},
 		},
@@ -196,6 +201,30 @@ func TestCreateManagerWithWorkersBootstrapsCatchupRangesIntoStatusRegistry(t *te
 	require.Len(t, resp.Networks, 1)
 	require.Equal(t, 1, resp.Networks[0].CatchupRanges)
 	require.Equal(t, uint64(10), resp.Networks[0].CatchupPendingBlocks)
+}
+
+// dialTestRedis connects to a local Redis, skipping the test when unavailable.
+func dialTestRedis(t *testing.T) infra.RedisClient {
+	t.Helper()
+	rc, err := infra.NewRedisClient("localhost:6379", "", "test", false)
+	if err != nil {
+		t.Skip("Redis not available, skipping test")
+	}
+	if err := rc.GetClient().Ping(context.Background()).Err(); err != nil {
+		t.Skip("Redis not available, skipping test")
+	}
+	t.Cleanup(func() { _ = rc.Close() })
+	return rc
+}
+
+func flushCatchupKeys(t *testing.T, rc infra.RedisClient, chain string) {
+	t.Helper()
+	ctx := context.Background()
+	keys := []string{"catchup_progress:" + chain, "catchup_migrated:" + chain}
+	if err := rc.GetClient().Del(ctx, keys...).Err(); err != nil {
+		t.Fatalf("flush catchup keys: %v", err)
+	}
+	t.Cleanup(func() { _ = rc.GetClient().Del(ctx, keys...).Err() })
 }
 
 type noopKVStore struct{}

--- a/internal/worker/manual.go
+++ b/internal/worker/manual.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/events"
 	"github.com/fystack/multichain-indexer/pkg/infra"
 	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/fystack/multichain-indexer/pkg/store/catchupstore"
 	"github.com/fystack/multichain-indexer/pkg/store/missingblockstore"
 	"github.com/fystack/multichain-indexer/pkg/store/pubkeystore"
 )
@@ -39,6 +40,7 @@ func NewManualWorker(
 	kv infra.KVStore,
 	redisClient infra.RedisClient,
 	blockStore blockstore.Store,
+	catchupStore catchupstore.Store,
 	emitter events.Emitter,
 	pubkeyStore pubkeystore.Store,
 	failedChan chan FailedBlockEvent,
@@ -51,6 +53,7 @@ func NewManualWorker(
 			cfg,
 			kv,
 			blockStore,
+			catchupStore,
 			emitter,
 			pubkeyStore,
 			ModeManual,

--- a/internal/worker/mempool.go
+++ b/internal/worker/mempool.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/events"
 	"github.com/fystack/multichain-indexer/pkg/infra"
 	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/fystack/multichain-indexer/pkg/store/catchupstore"
 	"github.com/fystack/multichain-indexer/pkg/store/pubkeystore"
 )
 
@@ -31,6 +32,7 @@ func NewMempoolWorker(
 	cfg config.ChainConfig,
 	kv infra.KVStore,
 	blockStore blockstore.Store,
+	catchupStore catchupstore.Store,
 	emitter events.Emitter,
 	pubkeyStore pubkeystore.Store,
 	failedChan chan FailedBlockEvent,
@@ -42,6 +44,7 @@ func NewMempoolWorker(
 		cfg,
 		kv,
 		blockStore,
+		catchupStore,
 		emitter,
 		pubkeyStore,
 		ModeMempool,

--- a/internal/worker/regular.go
+++ b/internal/worker/regular.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/infra"
 	"github.com/fystack/multichain-indexer/pkg/retry"
 	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/fystack/multichain-indexer/pkg/store/catchupstore"
 	"github.com/fystack/multichain-indexer/pkg/store/pubkeystore"
 )
 
@@ -46,6 +47,7 @@ func NewRegularWorker(
 	cfg config.ChainConfig,
 	kv infra.KVStore,
 	blockStore blockstore.Store,
+	catchupStore catchupstore.Store,
 	emitter events.Emitter,
 	pubkeyStore pubkeystore.Store,
 	failedChan chan FailedBlockEvent,
@@ -57,6 +59,7 @@ func NewRegularWorker(
 		cfg,
 		kv,
 		blockStore,
+		catchupStore,
 		emitter,
 		pubkeyStore,
 		ModeRegular,
@@ -238,7 +241,7 @@ func (rw *RegularWorker) queueCatchupRanges(start, end uint64) []blockstore.Catc
 		Start: start, End: end, Current: start - 1,
 	}, MAX_RANGE_SIZE)
 
-	if err := rw.blockStore.SaveCatchupRanges(rw.chain.GetNetworkInternalCode(), ranges); err != nil {
+	if err := rw.catchupStore.SaveRanges(rw.ctx, rw.chain.GetNetworkInternalCode(), ranges); err != nil {
 		rw.logger.Error("Failed to save catchup ranges",
 			"count", len(ranges),
 			"error", err,

--- a/internal/worker/regular_test.go
+++ b/internal/worker/regular_test.go
@@ -288,6 +288,7 @@ func TestCatchupWorkerUpdatesCatchupRegistryOnProgressAndCompletion(t *testing.T
 			logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
 			chain:          &stubIndexer{name: "ethereum", internalCode: "ETH", networkType: enum.NetworkTypeEVM},
 			blockStore:     store,
+			catchupStore:   stubCatchupStore{},
 			statusRegistry: statusRegistry,
 		},
 		blockRanges: []blockstore.CatchupRange{{
@@ -327,13 +328,14 @@ func newTestRegularWorker(chain *stubIndexer, store *stubBlockStore, currentBloc
 
 	return &RegularWorker{
 		BaseWorker: &BaseWorker{
-			ctx:        context.Background(),
-			cancel:     func() {},
-			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
-			config:     cfg,
-			chain:      chain,
-			blockStore: store,
-			failedChan: make(chan FailedBlockEvent, 1),
+			ctx:          context.Background(),
+			cancel:       func() {},
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			config:       cfg,
+			chain:        chain,
+			blockStore:   store,
+			catchupStore: stubCatchupStore{},
+			failedChan:   make(chan FailedBlockEvent, 1),
 		},
 		currentBlock: currentBlock,
 		blockHashes:  make([]blockstore.BlockHashEntry, 0, MaxBlockHashSize),
@@ -397,6 +399,19 @@ func (s *stubIndexer) GetBlocksByNumbers(context.Context, []uint64) ([]indexer.B
 func (s *stubIndexer) IsHealthy() bool {
 	return true
 }
+
+type stubCatchupStore struct{}
+
+func (stubCatchupStore) SaveRanges(context.Context, string, []blockstore.CatchupRange) error {
+	return nil
+}
+func (stubCatchupStore) SaveProgress(context.Context, string, uint64, uint64, uint64) error {
+	return nil
+}
+func (stubCatchupStore) GetProgress(context.Context, string) ([]blockstore.CatchupRange, error) {
+	return nil, nil
+}
+func (stubCatchupStore) DeleteRange(context.Context, string, uint64, uint64) error { return nil }
 
 type stubBlockStore struct {
 	mu                     sync.Mutex

--- a/internal/worker/rescanner.go
+++ b/internal/worker/rescanner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fystack/multichain-indexer/pkg/events"
 	"github.com/fystack/multichain-indexer/pkg/infra"
 	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/fystack/multichain-indexer/pkg/store/catchupstore"
 	"github.com/fystack/multichain-indexer/pkg/store/pubkeystore"
 )
 
@@ -43,6 +44,7 @@ func NewRescannerWorker(
 	cfg config.ChainConfig,
 	kv infra.KVStore,
 	blockStore blockstore.Store,
+	catchupStore catchupstore.Store,
 	emitter events.Emitter,
 	pubkeyStore pubkeystore.Store,
 	failedChan chan FailedBlockEvent,
@@ -55,6 +57,7 @@ func NewRescannerWorker(
 			cfg,
 			kv,
 			blockStore,
+			catchupStore,
 			emitter,
 			pubkeyStore,
 			ModeRescanner,

--- a/pkg/infra/kvstore.go
+++ b/pkg/infra/kvstore.go
@@ -7,7 +7,6 @@ import (
 )
 
 // KVStore is an interface for key-value stores.
-// There are multiple implementations available like Redis, BadgerDB, Postgres, etcd, etc.
 
 type KVPair struct {
 	Key   string

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -7,7 +7,6 @@ var (
 	ErrKeyEmpty    = errors.New("key is empty")
 )
 
-// checkKeyAndValue returns an error if k == "" or if v == nil.
 func checkKeyAndValue(k string, v any) error {
 	if k == "" {
 		return ErrKeyEmpty

--- a/pkg/kvstore/redis.go
+++ b/pkg/kvstore/redis.go
@@ -13,7 +13,6 @@ import (
 
 const redisOpTimeout = 5 * time.Second
 
-// RedisStore implements infra.KVStore on top of a Redis client.
 type RedisStore struct {
 	client *redis.Client
 	prefix string
@@ -104,8 +103,7 @@ func (r *RedisStore) GetAny(k string, v any) (bool, error) {
 	return true, r.codec.Unmarshal(data, v)
 }
 
-// List returns all key-value pairs whose key starts with prefix. It uses SCAN
-// (non-blocking, cursor-based) rather than KEYS to avoid stalling Redis.
+// List uses SCAN rather than KEYS to avoid stalling Redis.
 func (r *RedisStore) List(prefix string) ([]*infra.KVPair, error) {
 	if prefix == "" {
 		return nil, errors.New("prefix is empty")
@@ -158,9 +156,8 @@ func (r *RedisStore) List(prefix string) ([]*infra.KVPair, error) {
 	return result, nil
 }
 
-// BatchSet writes multiple key-value pairs in a single pipeline. Unlike Consul's
-// transaction API this is not atomic, which is acceptable for the idempotent
-// state (catchup ranges) written through it.
+// BatchSet pipelines the writes; not atomic, which is fine for the idempotent
+// catchup-range state written through it.
 func (r *RedisStore) BatchSet(pairs []infra.KVPair) error {
 	if len(pairs) == 0 {
 		return nil

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -27,8 +27,8 @@ var (
 	// https://github.com/jackc/pgerrcode/blob/master/errcode.go
 	UniqueViolation     = "23505"
 	ForeignKeyViolation = "23503"
-	// InvalidTextRepresentation (22P02) e.g. filtering by an enum value the DB
-	// type does not define — treated as no matching rows.
+	// InvalidTextRepresentation: e.g. filtering by an enum value the DB type
+	// does not define — treated as no matching rows.
 	InvalidTextRepresentation = "22P02"
 )
 
@@ -85,8 +85,7 @@ func (r *repository[T]) WrapError(ctx context.Context, err error) error {
 		return nil
 	}
 
-	// Filtering by an enum value the DB type does not define (22P02): no such
-	// rows exist, so treat it as an empty result rather than a hard error.
+	// Unknown enum value (22P02): no rows can match, so return empty, not error.
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) && pgErr.Code == InvalidTextRepresentation {
 		return nil

--- a/pkg/store/catchupstore/store.go
+++ b/pkg/store/catchupstore/store.go
@@ -1,11 +1,6 @@
-// Package catchupstore persists catchup progress as a compact per-chain Redis
-// hash instead of one KV key per range. Each chain keeps a single hash
-//
-//	catchup_progress:<chain>  { "<start>-<end>": "<current>" }
-//
-// so loading progress is a single HGETALL rather than a prefix scan over tens of
-// thousands of keys (see issue #88). Unlike missingblockstore it has no
-// claim/lock semantics — catchup scheduling is unchanged, only persistence.
+// Package catchupstore persists catchup progress as one compact Redis hash per
+// chain, catchup_progress:<chain> { "<start>-<end>": "<current>" }, so loading
+// is a single HGETALL rather than a scan over tens of thousands of keys (#88).
 package catchupstore
 
 import (
@@ -28,76 +23,66 @@ const (
 	defaultTimeout    = 5 * time.Second
 )
 
-// addRangesScript atomically inserts a range, merging it with any existing
-// overlapping or adjacent ranges into a single field. Returns the merged bounds.
+// addRangesScript merges the incoming ranges (flat (start,end,current) triplets
+// in ARGV) with existing overlapping/adjacent ones in a single HGETALL + rewrite,
+// keeping the whole save O(n) in one round-trip.
 const addRangesScript = `
 	local key = KEYS[1]
-	local newStart = tonumber(ARGV[1])
-	local newEnd = tonumber(ARGV[2])
-	local newCurrent = tonumber(ARGV[3])
 
-	if not newStart or not newEnd or newStart <= 0 or newEnd < newStart then
-		return redis.error_reply("invalid catchup range")
+	local function clamp(r)
+		if r.current > r.e then r.current = r.e end
+		if r.current + 1 < r.s then r.current = r.s - 1 end
 	end
 
-	if newCurrent > newEnd then
-		newCurrent = newEnd
-	end
-	if newCurrent + 1 < newStart then
-		newCurrent = newStart - 1
-	end
+	local ranges = {}
 
-	local mergedStart = newStart
-	local mergedEnd = newEnd
-	local mergedCurrent = newCurrent
 	local entries = redis.call('HGETALL', key)
-
 	for i = 1, #entries, 2 do
-		local field = entries[i]
-		local value = entries[i + 1]
-		local existingStart, existingEnd = string.match(field, '^(%d+)%-(%d+)$')
-		if existingStart and existingEnd then
-			existingStart = tonumber(existingStart)
-			existingEnd = tonumber(existingEnd)
-			local existingCurrent = tonumber(value)
-
-			if existingCurrent then
-				if existingCurrent > existingEnd then
-					existingCurrent = existingEnd
-				end
-				if existingCurrent + 1 < existingStart then
-					existingCurrent = existingStart - 1
-				end
-
-				if existingStart <= mergedEnd + 1 and existingEnd + 1 >= mergedStart then
-					if existingStart < mergedStart then
-						mergedStart = existingStart
-					end
-					if existingEnd > mergedEnd then
-						mergedEnd = existingEnd
-					end
-					if existingCurrent < mergedCurrent then
-						mergedCurrent = existingCurrent
-					end
-					redis.call('HDEL', key, field)
-				end
-			end
+		local existingStart, existingEnd = string.match(entries[i], '^(%d+)%-(%d+)$')
+		local existingCurrent = tonumber(entries[i + 1])
+		if existingStart and existingEnd and existingCurrent then
+			local r = {s = tonumber(existingStart), e = tonumber(existingEnd), current = existingCurrent}
+			clamp(r)
+			ranges[#ranges + 1] = r
 		end
 	end
 
-	if mergedCurrent > mergedEnd then
-		mergedCurrent = mergedEnd
-	end
-	if mergedCurrent + 1 < mergedStart then
-		mergedCurrent = mergedStart - 1
+	for i = 1, #ARGV, 3 do
+		local s = tonumber(ARGV[i])
+		local e = tonumber(ARGV[i + 1])
+		local current = tonumber(ARGV[i + 2])
+		if not s or not e or s <= 0 or e < s then
+			return redis.error_reply("invalid catchup range")
+		end
+		local r = {s = s, e = e, current = current}
+		clamp(r)
+		ranges[#ranges + 1] = r
 	end
 
-	local mergedField = tostring(mergedStart) .. '-' .. tostring(mergedEnd)
-	redis.call('HSET', key, mergedField, tostring(mergedCurrent))
-	return {mergedStart, mergedEnd, mergedCurrent}
+	table.sort(ranges, function(a, b)
+		if a.s ~= b.s then return a.s < b.s end
+		return a.e < b.e
+	end)
+
+	local merged = {}
+	for _, r in ipairs(ranges) do
+		local last = merged[#merged]
+		if last and r.s <= last.e + 1 then
+			if r.e > last.e then last.e = r.e end
+			if r.current < last.current then last.current = r.current end
+			clamp(last)
+		else
+			merged[#merged + 1] = r
+		end
+	end
+
+	redis.call('DEL', key)
+	for _, r in ipairs(merged) do
+		redis.call('HSET', key, tostring(r.s) .. '-' .. tostring(r.e), tostring(r.current))
+	end
+	return #merged
 `
 
-// Store persists catchup ranges and their progress for a chain.
 type Store interface {
 	SaveRanges(ctx context.Context, chain string, ranges []blockstore.CatchupRange) error
 	SaveProgress(ctx context.Context, chain string, start, end, current uint64) error
@@ -117,13 +102,11 @@ func (noopStore) DeleteRange(context.Context, string, uint64, uint64) error { re
 type catchupStore struct {
 	redisClient infra.RedisClient
 	addScript   *redis.Script
-	// legacy is the previous one-key-per-range store, read once per chain to
-	// migrate existing progress into the hash. May be nil.
+	// legacy is the previous one-key-per-range store, migrated in once per chain. May be nil.
 	legacy blockstore.Store
 }
 
 // New returns a Redis-backed store, or a no-op store when Redis is unavailable.
-// legacy is the previous KV-backed blockstore used for one-time migration.
 func New(redisClient infra.RedisClient, legacy blockstore.Store) Store {
 	if redisClient == nil || redisClient.GetClient() == nil {
 		return noopStore{}
@@ -175,22 +158,27 @@ func (s *catchupStore) SaveRanges(
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-
-	key := composeKey(chain)
+	args := make([]any, 0, len(ranges)*3)
 	for _, r := range ranges {
 		if r.Start == 0 || r.End < r.Start {
 			continue
 		}
-		if _, err := s.addScript.Run(
-			ctx,
-			s.redisClient.GetClient(),
-			[]string{key},
-			r.Start, r.End, r.Current,
-		).Result(); err != nil {
-			return fmt.Errorf("save catchup ranges: %w", err)
-		}
+		args = append(args, r.Start, r.End, r.Current)
+	}
+	if len(args) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	if _, err := s.addScript.Run(
+		ctx,
+		s.redisClient.GetClient(),
+		[]string{composeKey(chain)},
+		args...,
+	).Result(); err != nil {
+		return fmt.Errorf("save catchup ranges: %w", err)
 	}
 	return nil
 }
@@ -268,9 +256,8 @@ func (s *catchupStore) DeleteRange(
 	return nil
 }
 
-// migrateFromLegacy copies one-key-per-range progress from the legacy KV store
-// into the hash exactly once per chain. A marker key suppresses further legacy
-// reads even after the hash later empties out.
+// migrateFromLegacy copies legacy KV progress into the hash once per chain,
+// guarded by a marker key so it isn't re-read after the hash later empties out.
 func (s *catchupStore) migrateFromLegacy(ctx context.Context, chain string) error {
 	if s.legacy == nil {
 		return nil
@@ -295,8 +282,7 @@ func (s *catchupStore) migrateFromLegacy(ctx context.Context, chain string) erro
 		}
 	}
 
-	// Mark migrated regardless of whether legacy had data, so an empty legacy
-	// store doesn't cause a re-read on every GetProgress.
+	// Mark migrated even when legacy was empty, to avoid a re-read on every GetProgress.
 	if err := s.redisClient.GetClient().Set(mctx, marker, "1", 0).Err(); err != nil {
 		return fmt.Errorf("set catchup migration marker: %w", err)
 	}

--- a/pkg/store/catchupstore/store.go
+++ b/pkg/store/catchupstore/store.go
@@ -1,0 +1,338 @@
+// Package catchupstore persists catchup progress as a compact per-chain Redis
+// hash instead of one KV key per range. Each chain keeps a single hash
+//
+//	catchup_progress:<chain>  { "<start>-<end>": "<current>" }
+//
+// so loading progress is a single HGETALL rather than a prefix scan over tens of
+// thousands of keys (see issue #88). Unlike missingblockstore it has no
+// claim/lock semantics — catchup scheduling is unchanged, only persistence.
+package catchupstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fystack/multichain-indexer/pkg/infra"
+	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	progressKeyPrefix = "catchup_progress"
+	migratedKeyPrefix = "catchup_migrated"
+	defaultTimeout    = 5 * time.Second
+)
+
+// addRangesScript atomically inserts a range, merging it with any existing
+// overlapping or adjacent ranges into a single field. Returns the merged bounds.
+const addRangesScript = `
+	local key = KEYS[1]
+	local newStart = tonumber(ARGV[1])
+	local newEnd = tonumber(ARGV[2])
+	local newCurrent = tonumber(ARGV[3])
+
+	if not newStart or not newEnd or newStart <= 0 or newEnd < newStart then
+		return redis.error_reply("invalid catchup range")
+	end
+
+	if newCurrent > newEnd then
+		newCurrent = newEnd
+	end
+	if newCurrent + 1 < newStart then
+		newCurrent = newStart - 1
+	end
+
+	local mergedStart = newStart
+	local mergedEnd = newEnd
+	local mergedCurrent = newCurrent
+	local entries = redis.call('HGETALL', key)
+
+	for i = 1, #entries, 2 do
+		local field = entries[i]
+		local value = entries[i + 1]
+		local existingStart, existingEnd = string.match(field, '^(%d+)%-(%d+)$')
+		if existingStart and existingEnd then
+			existingStart = tonumber(existingStart)
+			existingEnd = tonumber(existingEnd)
+			local existingCurrent = tonumber(value)
+
+			if existingCurrent then
+				if existingCurrent > existingEnd then
+					existingCurrent = existingEnd
+				end
+				if existingCurrent + 1 < existingStart then
+					existingCurrent = existingStart - 1
+				end
+
+				if existingStart <= mergedEnd + 1 and existingEnd + 1 >= mergedStart then
+					if existingStart < mergedStart then
+						mergedStart = existingStart
+					end
+					if existingEnd > mergedEnd then
+						mergedEnd = existingEnd
+					end
+					if existingCurrent < mergedCurrent then
+						mergedCurrent = existingCurrent
+					end
+					redis.call('HDEL', key, field)
+				end
+			end
+		end
+	end
+
+	if mergedCurrent > mergedEnd then
+		mergedCurrent = mergedEnd
+	end
+	if mergedCurrent + 1 < mergedStart then
+		mergedCurrent = mergedStart - 1
+	end
+
+	local mergedField = tostring(mergedStart) .. '-' .. tostring(mergedEnd)
+	redis.call('HSET', key, mergedField, tostring(mergedCurrent))
+	return {mergedStart, mergedEnd, mergedCurrent}
+`
+
+// Store persists catchup ranges and their progress for a chain.
+type Store interface {
+	SaveRanges(ctx context.Context, chain string, ranges []blockstore.CatchupRange) error
+	SaveProgress(ctx context.Context, chain string, start, end, current uint64) error
+	GetProgress(ctx context.Context, chain string) ([]blockstore.CatchupRange, error)
+	DeleteRange(ctx context.Context, chain string, start, end uint64) error
+}
+
+type noopStore struct{}
+
+func (noopStore) SaveRanges(context.Context, string, []blockstore.CatchupRange) error { return nil }
+func (noopStore) SaveProgress(context.Context, string, uint64, uint64, uint64) error  { return nil }
+func (noopStore) GetProgress(context.Context, string) ([]blockstore.CatchupRange, error) {
+	return nil, nil
+}
+func (noopStore) DeleteRange(context.Context, string, uint64, uint64) error { return nil }
+
+type catchupStore struct {
+	redisClient infra.RedisClient
+	addScript   *redis.Script
+	// legacy is the previous one-key-per-range store, read once per chain to
+	// migrate existing progress into the hash. May be nil.
+	legacy blockstore.Store
+}
+
+// New returns a Redis-backed store, or a no-op store when Redis is unavailable.
+// legacy is the previous KV-backed blockstore used for one-time migration.
+func New(redisClient infra.RedisClient, legacy blockstore.Store) Store {
+	if redisClient == nil || redisClient.GetClient() == nil {
+		return noopStore{}
+	}
+	return &catchupStore{
+		redisClient: redisClient,
+		addScript:   redis.NewScript(addRangesScript),
+		legacy:      legacy,
+	}
+}
+
+func composeKey(chain string) string {
+	return fmt.Sprintf("%s:%s", progressKeyPrefix, chain)
+}
+
+func composeMigratedKey(chain string) string {
+	return fmt.Sprintf("%s:%s", migratedKeyPrefix, chain)
+}
+
+func composeField(start, end uint64) string {
+	return fmt.Sprintf("%d-%d", start, end)
+}
+
+func parseField(field string) (uint64, uint64, bool) {
+	parts := strings.Split(field, "-")
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	end, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil || end < start || start == 0 {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+func (s *catchupStore) SaveRanges(
+	ctx context.Context,
+	chain string,
+	ranges []blockstore.CatchupRange,
+) error {
+	if chain == "" {
+		return errors.New("chain name is required")
+	}
+	if len(ranges) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	key := composeKey(chain)
+	for _, r := range ranges {
+		if r.Start == 0 || r.End < r.Start {
+			continue
+		}
+		if _, err := s.addScript.Run(
+			ctx,
+			s.redisClient.GetClient(),
+			[]string{key},
+			r.Start, r.End, r.Current,
+		).Result(); err != nil {
+			return fmt.Errorf("save catchup ranges: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *catchupStore) SaveProgress(
+	ctx context.Context,
+	chain string,
+	start, end, current uint64,
+) error {
+	if chain == "" || start == 0 || end < start {
+		return errors.New("invalid catchup range")
+	}
+	if current > end {
+		current = end
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	if err := s.redisClient.GetClient().
+		HSet(ctx, composeKey(chain), composeField(start, end), strconv.FormatUint(current, 10)).
+		Err(); err != nil {
+		return fmt.Errorf("save catchup progress: %w", err)
+	}
+	return nil
+}
+
+func (s *catchupStore) GetProgress(
+	ctx context.Context,
+	chain string,
+) ([]blockstore.CatchupRange, error) {
+	if chain == "" {
+		return nil, errors.New("chain name is required")
+	}
+
+	if err := s.migrateFromLegacy(ctx, chain); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	values, err := s.redisClient.GetClient().HGetAll(ctx, composeKey(chain)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("get catchup progress: %w", err)
+	}
+	return parseProgressMap(values), nil
+}
+
+func (s *catchupStore) DeleteRange(
+	ctx context.Context,
+	chain string,
+	start, end uint64,
+) error {
+	if chain == "" || start == 0 || end < start {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	key := composeKey(chain)
+	pipe := s.redisClient.GetClient().Pipeline()
+	pipe.HDel(ctx, key, composeField(start, end))
+	lenCmd := pipe.HLen(ctx, key)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("delete catchup range: %w", err)
+	}
+	// Drop the empty hash so the chain leaves no dangling key.
+	if lenCmd.Val() == 0 {
+		if err := s.redisClient.GetClient().Del(ctx, key).Err(); err != nil {
+			return fmt.Errorf("cleanup catchup key: %w", err)
+		}
+	}
+	return nil
+}
+
+// migrateFromLegacy copies one-key-per-range progress from the legacy KV store
+// into the hash exactly once per chain. A marker key suppresses further legacy
+// reads even after the hash later empties out.
+func (s *catchupStore) migrateFromLegacy(ctx context.Context, chain string) error {
+	if s.legacy == nil {
+		return nil
+	}
+
+	mctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	marker := composeMigratedKey(chain)
+	exists, err := s.redisClient.GetClient().Exists(mctx, marker).Result()
+	if err != nil {
+		return fmt.Errorf("check catchup migration marker: %w", err)
+	}
+	if exists == 1 {
+		return nil
+	}
+
+	legacyRanges, err := s.legacy.GetCatchupProgress(chain)
+	if err == nil && len(legacyRanges) > 0 {
+		if err := s.SaveRanges(ctx, chain, legacyRanges); err != nil {
+			return fmt.Errorf("migrate catchup ranges: %w", err)
+		}
+	}
+
+	// Mark migrated regardless of whether legacy had data, so an empty legacy
+	// store doesn't cause a re-read on every GetProgress.
+	if err := s.redisClient.GetClient().Set(mctx, marker, "1", 0).Err(); err != nil {
+		return fmt.Errorf("set catchup migration marker: %w", err)
+	}
+	return nil
+}
+
+func parseProgressMap(values map[string]string) []blockstore.CatchupRange {
+	ranges := make([]blockstore.CatchupRange, 0, len(values))
+	for field, currentText := range values {
+		start, end, ok := parseField(field)
+		if !ok {
+			continue
+		}
+		current, err := strconv.ParseUint(currentText, 10, 64)
+		if err != nil {
+			continue
+		}
+		if current > end {
+			current = end
+		}
+		ranges = append(ranges, blockstore.CatchupRange{Start: start, End: end, Current: current})
+	}
+
+	slices.SortFunc(ranges, func(a, b blockstore.CatchupRange) int {
+		switch {
+		case a.Start < b.Start:
+			return -1
+		case a.Start > b.Start:
+			return 1
+		case a.End < b.End:
+			return -1
+		case a.End > b.End:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return ranges
+}

--- a/pkg/store/catchupstore/store_test.go
+++ b/pkg/store/catchupstore/store_test.go
@@ -1,0 +1,157 @@
+package catchupstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/fystack/multichain-indexer/pkg/common/constant"
+	"github.com/fystack/multichain-indexer/pkg/infra"
+	"github.com/fystack/multichain-indexer/pkg/store/blockstore"
+	"github.com/stretchr/testify/require"
+)
+
+func dialRedis(t *testing.T) infra.RedisClient {
+	t.Helper()
+	rc, err := infra.NewRedisClient("localhost:6379", "", "test", false)
+	if err != nil {
+		t.Skip("Redis not available, skipping test")
+	}
+	if err := rc.GetClient().Ping(context.Background()).Err(); err != nil {
+		t.Skip("Redis not available, skipping test")
+	}
+	t.Cleanup(func() { _ = rc.Close() })
+	return rc
+}
+
+func cleanupChain(t *testing.T, rc infra.RedisClient, chain string) {
+	t.Helper()
+	ctx := context.Background()
+	keys := []string{composeKey(chain), composeMigratedKey(chain)}
+	require.NoError(t, rc.GetClient().Del(ctx, keys...).Err())
+	t.Cleanup(func() { _ = rc.GetClient().Del(ctx, keys...).Err() })
+}
+
+func TestSaveRangesAndGetProgressSorted(t *testing.T) {
+	rc := dialRedis(t)
+	chain := fmt.Sprintf("test_sorted_%d", 1)
+	cleanupChain(t, rc, chain)
+
+	s := New(rc, nil)
+	ctx := context.Background()
+
+	require.NoError(t, s.SaveRanges(ctx, chain, []blockstore.CatchupRange{
+		{Start: 30, End: 39, Current: 29},
+		{Start: 1, End: 10, Current: 5},
+	}))
+
+	got, err := s.GetProgress(ctx, chain)
+	require.NoError(t, err)
+	require.Equal(t, []blockstore.CatchupRange{
+		{Start: 1, End: 10, Current: 5},
+		{Start: 30, End: 39, Current: 29},
+	}, got)
+}
+
+func TestSaveProgressUpdatesCurrent(t *testing.T) {
+	rc := dialRedis(t)
+	chain := "test_progress"
+	cleanupChain(t, rc, chain)
+
+	s := New(rc, nil)
+	ctx := context.Background()
+
+	require.NoError(t, s.SaveRanges(ctx, chain, []blockstore.CatchupRange{{Start: 1, End: 20, Current: 0}}))
+	require.NoError(t, s.SaveProgress(ctx, chain, 1, 20, 12))
+
+	got, err := s.GetProgress(ctx, chain)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, uint64(12), got[0].Current)
+}
+
+func TestDeleteFinalRangeClearsKey(t *testing.T) {
+	rc := dialRedis(t)
+	chain := "test_delete"
+	cleanupChain(t, rc, chain)
+
+	s := New(rc, nil)
+	ctx := context.Background()
+
+	require.NoError(t, s.SaveRanges(ctx, chain, []blockstore.CatchupRange{{Start: 1, End: 5, Current: 0}}))
+	require.NoError(t, s.DeleteRange(ctx, chain, 1, 5))
+
+	exists, err := rc.GetClient().Exists(ctx, composeKey(chain)).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), exists, "hash key should be removed once empty")
+}
+
+func TestSaveRangesMergesOverlapping(t *testing.T) {
+	rc := dialRedis(t)
+	chain := "test_merge"
+	cleanupChain(t, rc, chain)
+
+	s := New(rc, nil)
+	ctx := context.Background()
+
+	require.NoError(t, s.SaveRanges(ctx, chain, []blockstore.CatchupRange{{Start: 1, End: 10, Current: 4}}))
+	// Adjacent range should merge into a single field.
+	require.NoError(t, s.SaveRanges(ctx, chain, []blockstore.CatchupRange{{Start: 11, End: 20, Current: 15}}))
+
+	got, err := s.GetProgress(ctx, chain)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, blockstore.CatchupRange{Start: 1, End: 20, Current: 4}, got[0])
+}
+
+// fakeKV is a minimal infra.KVStore exposing seeded catchup pairs via List.
+type fakeKV struct {
+	pairs []*infra.KVPair
+}
+
+func (fakeKV) GetName() string                  { return "fake" }
+func (fakeKV) Set(string, string) error         { return nil }
+func (fakeKV) Get(string) (string, error)       { return "", nil }
+func (fakeKV) SetAny(string, any) error         { return nil }
+func (fakeKV) GetAny(string, any) (bool, error) { return false, nil }
+func (f fakeKV) List(prefix string) ([]*infra.KVPair, error) {
+	var out []*infra.KVPair
+	for _, p := range f.pairs {
+		if len(p.Key) >= len(prefix) && p.Key[:len(prefix)] == prefix {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+func (fakeKV) Delete(string) error           { return nil }
+func (fakeKV) BatchSet([]infra.KVPair) error { return nil }
+func (fakeKV) Close() error                  { return nil }
+
+func TestLazyMigrationFromLegacyKV(t *testing.T) {
+	rc := dialRedis(t)
+	chain := "test_migrate"
+	cleanupChain(t, rc, chain)
+
+	// Legacy one-key-per-range entry: block_states/<chain>/catchup_progress/1-20 -> 10
+	legacyKey := fmt.Sprintf(
+		"%s/%s/%s/%d-%d",
+		blockstore.BlockStates, chain, constant.KVPrefixProgressCatchup, 1, 20,
+	)
+	legacy := blockstore.NewBlockStore(fakeKV{pairs: []*infra.KVPair{{
+		Key:   legacyKey,
+		Value: []byte("10"),
+	}}})
+
+	s := New(rc, legacy)
+	ctx := context.Background()
+
+	got, err := s.GetProgress(ctx, chain)
+	require.NoError(t, err)
+	require.Equal(t, []blockstore.CatchupRange{{Start: 1, End: 20, Current: 10}}, got)
+
+	// Marker must suppress a second migration even after the hash empties.
+	require.NoError(t, s.DeleteRange(ctx, chain, 1, 20))
+	got, err = s.GetProgress(ctx, chain)
+	require.NoError(t, err)
+	require.Empty(t, got, "completed ranges must not be re-migrated from legacy KV")
+}


### PR DESCRIPTION
Top of the stack. Stacked on #110.

- feat(catchup): store catchup progress in one compact per-chain Redis hash `catchup_progress:<chain>` instead of one KV key per range — loading is a single HGETALL instead of a scan over tens of thousands of keys (#88)
- fix(catchup): save all ranges in a single Redis round-trip

  `SaveRanges` ran the merge Lua script once per range, each doing a full HGETALL over the growing hash — O(n²) and ~28k round-trips for a large gap, blowing the 5s timeout so nothing persisted and catchup stalled. Now all ranges are passed as flat `(start,end,current)` triplets to one script that does a single HGETALL, merges in memory, and rewrites the hash.

**Stack:** #109 → #110 → this PR